### PR TITLE
Docker Compose: full path to bash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - OLLAMA_NUM_PARALLEL=1 # Number of parallel request Ollama handle
       - OLLAMA_MODELS=/models # Path to models storage
       - PATH=/llm/ollama:$PATH
-    command: bash -c "/llm/ollama/ollama serve > /logs/ollama.log"
+    command: /bin/bash -c "/llm/ollama/ollama serve > /logs/ollama.log"
   open-webui:
     container_name: open-webui
     image: ghcr.io/open-webui/open-webui:v0.5.16


### PR DESCRIPTION
used a direct path to bash bin to fix error when container comes up of not finding bash binary